### PR TITLE
require fonttools >= 3.4.0

### DIFF
--- a/Lib/glyphsLib/__init__.py
+++ b/Lib/glyphsLib/__init__.py
@@ -28,7 +28,7 @@ from glyphsLib.parser import Parser
 from glyphsLib.util import write_ufo
 
 
-__version__ = "1.2.1.dev0"
+__version__ = "1.3.0.dev0"
 
 __all__ = [
     "build_masters", "build_instances", "load_to_ufos", "load", "loads",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-fonttools==3.3.2
+fonttools==3.4.0
 defcon==0.2.0
 MutatorMath==2.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.1.dev0
+current_version = 1.3.0.dev0
 commit = True
 tag = False
 tag_name = v{new_version}

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'pytest>=2.8',
     ],
     install_requires=[
-        "fonttools>=3.1.2",
+        "fonttools>=3.4.0",
         "defcon>=0.2.0",
         "MutatorMath>=2.0.0",
     ],

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open('README.rst', 'r') as f:
 
 setup(
     name='glyphsLib',
-    version='1.2.1.dev0',
+    version='1.3.0.dev0',
     author="James Godfrey-Kittle",
     author_email="jamesgk@google.com",
     description="A bridge from Glyphs source files (.glyphs) to UFOs",


### PR DESCRIPTION
And also bump the minor glyphsLib version to 1.3.0, to notify clients of the new feature, and of the increased minimum required version of fonttools.

(the pre-release suffix '.dev0' will be dropped once we actually release glyphsLib 1.3.0)